### PR TITLE
:bug: Let FreshRSS autoset tables prefix in queries

### DIFF
--- a/stats.php
+++ b/stats.php
@@ -35,7 +35,7 @@ FROM (
 		COUNT(1) AS count,
 		MIN(date) AS date_min,
 		MAX(date) AS date_max
-	FROM `entry`
+	FROM `_entry`
 	WHERE id_feed = {$feed->id()}
 ) stats
 SQL;
@@ -64,7 +64,7 @@ FROM (
 		COUNT(1) AS count,
 		MIN(date) AS date_min,
 		MAX(date) AS date_max
-	FROM `entry`
+	FROM `_entry`
 	GROUP BY id_feed
 ) AS stats
 LEFT JOIN `feed` ON feed.id = stats.id_feed


### PR DESCRIPTION
A prefix can be set for tables in Freshrss. Its [PDO](https://github.com/FreshRSS/FreshRSS/blob/edge/lib/Minz/Pdo.php) class can automatically handle this prefix in SQL queries when using the query(), exec() and prepare() methods as long as the tables' names have been prefixed by `_` in the query string.

This PR adds the `_` in the SQL query strings of the extension

Closes #3 