### PR TITLE
:bug: Add prefix to feed table in fetchAllStats() SQL

### DIFF
--- a/stats.php
+++ b/stats.php
@@ -67,7 +67,7 @@ FROM (
 	FROM `_entry`
 	GROUP BY id_feed
 ) AS stats
-LEFT JOIN `feed` ON feed.id = stats.id_feed
+LEFT JOIN `_feed` as feed ON feed.id = stats.id_feed
 ORDER BY avgTTL ASC
 SQL;
         $stm = $this->pdo->query($sql);


### PR DESCRIPTION
I forgot to apply the same fix as before to the feed table in query of the fetchAllStats() function, so the Feed frequency statistics stayed empty.

Sorry about that !