### PR TITLE
Don't save config during plugin init

### DIFF
--- a/extension.php
+++ b/extension.php
@@ -29,24 +29,10 @@ class AutoTTLExtension extends Minz_Extension
             'feedBeforeActualizeHook',
         ]);
         $this->registerTranslates();
-        $this->initConfig();
-    }
 
-    private function initConfig()
-    {
-        if (!FreshRSS_Context::userConf()->hasParam('auto_ttl_max_ttl')) {
-            FreshRSS_Context::userConf()->_attribute('auto_ttl_max_ttl', self::MAX_TTL);
-        }
-
-        if (!FreshRSS_Context::userConf()->hasParam('auto_ttl_stats_count')) {
-            FreshRSS_Context::userConf()->_attribute('auto_ttl_stats_count', self::STATS_COUNT);
-        }
-
-        FreshRSS_Context::userConf()->save();
-
-        $this->defaultTTL = FreshRSS_Context::userConf()->attributeInt('ttl_default');
-        $this->maxTTL = FreshRSS_Context::userConf()->attributeInt('auto_ttl_max_ttl');
-        $this->statsCount = FreshRSS_Context::userConf()->attributeInt('auto_ttl_stats_count');
+        $this->defaultTTL = FreshRSS_Context::userConf()->attributeInt('ttl_default') ?? FreshRSS_Feed::TTL_DEFAULT;
+        $this->maxTTL = FreshRSS_Context::userConf()->attributeInt('auto_ttl_max_ttl') ?? self::MAX_TTL;
+        $this->statsCount = FreshRSS_Context::userConf()->attributeInt('auto_ttl_stats_count') ?? self::STATS_COUNT;
     }
 
     /*


### PR DESCRIPTION
Fixes https://github.com/FreshRSS/FreshRSS/issues/8261.

Populate configured values or fallback to default values on init instead of saving the user conf every time.