### PR TITLE
Calculate avgTTL with last update, not last entry

### DIFF
--- a/extension.php
+++ b/extension.php
@@ -94,8 +94,9 @@ class AutoTTLExtension extends Minz_Extension
             return $feed;
         }
 
-        $timeSinceLastUpdate = time() - $feed->lastUpdate();
-        $ttl = $this->getStats()->getAdjustedTTL($feed->id());
+        $lastUpdate = $feed->lastUpdate();
+        $timeSinceLastUpdate = time() - $lastUpdate;
+        $ttl = $this->getStats()->getAdjustedTTL($feed->id(), $lastUpdate);
 
         if ($timeSinceLastUpdate < $ttl) {
             Minz_Log::debug(

--- a/stats.php
+++ b/stats.php
@@ -91,11 +91,11 @@ class AutoTTLStats extends Minz_ModelPdo
         return $avgTTL;
     }
 
-    public function getAdjustedTTL(int $feedID): int
+    public function getAdjustedTTL(int $feedID, int $lastUpdate): int
     {
         $sql = <<<SQL
 SELECT
-    COALESCE((MAX(stats.date) - MIN(stats.date)) / COUNT(1), 0) AS `avgTTL`
+    COALESCE(({$lastUpdate} - MIN(stats.date)) / COUNT(1), 0) AS `avgTTL`
 FROM `_entry` AS stats
 WHERE id_feed = {$feedID} AND date > {$this->getStatsCutoff()}
 SQL;
@@ -121,7 +121,7 @@ SELECT
     feed.name,
     feed.`lastUpdate`,
     feed.ttl,
-    COALESCE((MAX(stats.date) - MIN(stats.date)) / COUNT(1), 0) AS `avgTTL`
+    COALESCE((feed.`lastUpdate` - MIN(stats.date)) / COUNT(1), 0) AS `avgTTL`
 FROM `_feed` AS feed
 LEFT JOIN (
     SELECT id_feed, date
@@ -130,7 +130,7 @@ LEFT JOIN (
 ) AS stats ON feed.id = stats.id_feed
 WHERE {$where}
 GROUP BY feed.id
-ORDER BY COALESCE((MAX(stats.date) - MIN(stats.date)) / COUNT(1), 0) = 0, `avgTTL` ASC
+ORDER BY COALESCE((feed.`lastUpdate` - MIN(stats.date)) / COUNT(1), 0) = 0, `avgTTL` ASC
 LIMIT {$this->statsCount}
 SQL;
 

--- a/tests/AutoTTLStatsTest.php
+++ b/tests/AutoTTLStatsTest.php
@@ -98,10 +98,43 @@ final class AutoTTLStatsTest extends TestCase
 
             $stats = new AutoTTLStats($defaultTTL, $maxTTL, $statsCount);
             $stats->setTimeSource(new MockTime(strtotime("2000-01-02T00:00:00Z")));
-            $adjustedTTL = $stats->getAdjustedTTL($feed->id());
+            $adjustedTTL = $stats->getAdjustedTTL($feed->id(), strtotime("2000-01-01T16:00:00Z"));
 
             // (16:00 - 00:00) / 3 = 57600 seconds / 3 = 19200 seconds
             $this->assertSame(19200, $adjustedTTL);
+        } finally {
+            FreshRSS_feed_Controller::deleteFeed($feed->id());
+        }
+    }
+
+    public function test_get_avg_two_close(): void
+    {
+        $defaultTTL = 3600;
+        $maxTTL = 86400;
+        $statsCount = 100;
+
+        try {
+            $feed = FreshRSS_feed_Controller::addFeed('http://wiremock:8080/two_close.xml');
+
+            $stats = new AutoTTLStats($defaultTTL, $maxTTL, $statsCount);
+            $stats->setTimeSource(new MockTime(strtotime("2000-01-04T00:00:00Z")));
+
+            // Two updates in a row when we checked implies frequent updates.
+            // (00:02 - 00:00) / 2 = 2 seconds / 2 = 1 seconds < $default
+            $adjustedTTL = $stats->getAdjustedTTL($feed->id(), strtotime("2000-01-01T00:00:02Z"));
+            $this->assertSame($defaultTTL, $adjustedTTL);
+
+            // Two updates in a row, but hours ago, implies moderate updates.
+            // (16:00 - 00:00) / 2 = 57600 seconds / 2 = 28800 seconds
+            $adjustedTTL = $stats->getAdjustedTTL($feed->id(), strtotime("2000-01-01T16:00:00Z"));
+            $this->assertSame(28800, $adjustedTTL);
+
+            // Two updates in a row, but days ago, implies slow updates.
+            // 2 days > 1 day $maxTTL
+            $adjustedTTL = $stats->getAdjustedTTL($feed->id(), strtotime("2000-01-03T00:00:00Z"));
+            $this->assertSame($maxTTL, $adjustedTTL);
+
+
         } finally {
             FreshRSS_feed_Controller::deleteFeed($feed->id());
         }

--- a/wiremock/__files/two_close.xml
+++ b/wiremock/__files/two_close.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Example Feed</title>
+  <entry>
+    <title>One</title>
+    <updated>2000-01-01T00:00:00Z</updated>
+    <summary>Some text.</summary>
+  </entry>
+  <entry>
+    <title>Two</title>
+    <updated>2000-01-01T00:00:02Z</updated>
+    <summary>Some text.</summary>
+  </entry>
+</feed>


### PR DESCRIPTION
When updating and finding no new items, not updating the avgTTL accordingly artificially lowers it.

Fixes #25.