### PR TITLE
Fix manual feed update with AutoTTL enabled

### DIFF
--- a/extension.php
+++ b/extension.php
@@ -60,6 +60,16 @@ class AutoTTLExtension extends Minz_Extension
 
     public function feedBeforeActualizeHook(FreshRSS_Feed $feed)
     {
+        // A direct request for one feed is a user-initiated refresh.
+        // Do not let AutoTTL suppress it.
+        if (
+            Minz_Request::controllerName() === 'feed' &&
+            Minz_Request::actionName() === 'actualize' &&
+            Minz_Request::paramInt('id') === $feed->id()
+        ) {
+            return $feed;
+        }
+
         if ($feed->lastUpdate() === 0) {
             Minz_Log::debug(
                 sprintf(


### PR DESCRIPTION
Issue #30 
This edits now able to have the autoTTL to do feed refresh and not suppress the user initiated feed refresh. Previously when AutoTTL is enabled the manual refresh by clicking on update feed on left side of feed list setting or refresh at top of page won't work.