### PR TITLE
Throttle errored feeds and display deterministic 1h error jitter

### DIFF
--- a/configure.phtml
+++ b/configure.phtml
@@ -89,20 +89,23 @@ $now = time();
 				<?= $this->getStats()->humanIntervalFromSeconds($adjustedTTL) ?>
 			</td>
 			<td>
-				<?= ($feed->lastUpdate > 0) ? $this->getStats()->humanIntervalFromSeconds($now - $feed->lastUpdate).' ago' : 'never' ?>
+				<?= ($feed->lastUpdate > 0) ? $this->getStats()->humanIntervalFromSeconds($now - $feed->lastUpdate).' ago' : ($feed->lastError > 0 ? 'error ' . $this->getStats()->humanIntervalFromSeconds($now - $feed->lastError) . ' ago' : 'never') ?>
 			</td>
 			<td>
 				<?php
-                    if ($feed->lastUpdate > 0) {
-                        $timeUntil = $feed->lastUpdate + $adjustedTTL - $now;
+                    $lastAttempt = $feed->lastAttempt;
+                    if ($lastAttempt > 0) {
+                        $effectiveTTL = $adjustedTTL + $feed->errorJitter;
+                        $timeUntil = $lastAttempt + $effectiveTTL - $now;
+                        $jitterText = $feed->errorJitter > 0 ? ', +' . $this->getStats()->humanIntervalFromSeconds($feed->errorJitter) . ' jitter' : '';
                         if ($timeUntil > 0) {
                             $interval = $this->getStats()->humanIntervalFromSeconds($timeUntil);
-                            echo $interval;
+                            echo $feed->lastError > $feed->lastUpdate ? $interval . ' (in error' . $jitterText . ')' : $interval;
                         } else {
-                            echo 'pending';
+                            echo $feed->lastError > $feed->lastUpdate ? 'pending (in error' . $jitterText . ')' : 'pending';
                         }
                     } else {
-                        echo 'never updated';
+                        echo 'never attempted';
                     }
 		    ?>
 			</td>
@@ -138,21 +141,24 @@ $now = time();
 				<?= $this->getStats()->humanIntervalFromSeconds($feed->ttl) ?>
 			</td>
 			<td>
-				<?= ($feed->lastUpdate > 0) ? $this->getStats()->humanIntervalFromSeconds($now - $feed->lastUpdate).' ago' : 'never' ?>
+				<?= ($feed->lastUpdate > 0) ? $this->getStats()->humanIntervalFromSeconds($now - $feed->lastUpdate).' ago' : ($feed->lastError > 0 ? 'error ' . $this->getStats()->humanIntervalFromSeconds($now - $feed->lastError) . ' ago' : 'never') ?>
 			</td>
 			<td>
 				<?php
-		        if ($feed->lastUpdate > 0) {
-		            $timeUntil = $feed->lastUpdate + $feed->ttl - $now;
-		            if ($timeUntil > 0) {
-		                $interval = $this->getStats()->humanIntervalFromSeconds($timeUntil);
-		                echo $interval;
-		            } else {
-		                echo 'pending';
-		            }
-		        } else {
-		            echo 'never updated';
-		        }
+                    $lastAttempt = $feed->lastAttempt;
+                    if ($lastAttempt > 0) {
+                        $effectiveTTL = $feed->ttl + $feed->errorJitter;
+                        $timeUntil = $lastAttempt + $effectiveTTL - $now;
+                        $jitterText = $feed->errorJitter > 0 ? ', +' . $this->getStats()->humanIntervalFromSeconds($feed->errorJitter) . ' jitter' : '';
+                        if ($timeUntil > 0) {
+                            $interval = $this->getStats()->humanIntervalFromSeconds($timeUntil);
+                            echo $feed->lastError > $feed->lastUpdate ? $interval . ' (in error' . $jitterText . ')' : $interval;
+                        } else {
+                            echo $feed->lastError > $feed->lastUpdate ? 'pending (in error' . $jitterText . ')' : 'pending';
+                        }
+                    } else {
+                        echo 'never attempted';
+                    }
 		    ?>
 			</td>
 		</tr>

--- a/configure.phtml
+++ b/configure.phtml
@@ -89,25 +89,10 @@ $now = time();
 				<?= $this->getStats()->humanIntervalFromSeconds($adjustedTTL) ?>
 			</td>
 			<td>
-				<?= ($feed->lastError > $feed->lastUpdate) ? 'error ' . $this->getStats()->humanIntervalFromSeconds($now - $feed->lastError) . ' ago' : (($feed->lastUpdate > 0) ? $this->getStats()->humanIntervalFromSeconds($now - $feed->lastUpdate) . ' ago' : 'never') ?>
+				<?= $this->getStats()->formatLastAttempt($feed, $now) ?>
 			</td>
 			<td>
-				<?php
-                    $lastAttempt = $feed->lastAttempt;
-                    if ($lastAttempt > 0) {
-                        $effectiveTTL = $adjustedTTL + $feed->errorJitter;
-                        $timeUntil = $lastAttempt + $effectiveTTL - $now;
-                        $jitterText = $feed->errorJitter > 0 ? ', +' . $this->getStats()->humanIntervalFromSeconds($feed->errorJitter) . ' jitter' : '';
-                        if ($timeUntil > 0) {
-                            $interval = $this->getStats()->humanIntervalFromSeconds($timeUntil);
-                            echo $feed->lastError > $feed->lastUpdate ? $interval . ' (in error' . $jitterText . ')' : $interval;
-                        } else {
-                            echo $feed->lastError > $feed->lastUpdate ? 'pending (in error' . $jitterText . ')' : 'pending';
-                        }
-                    } else {
-                        echo 'never attempted';
-                    }
-		    ?>
+				<?= $this->getStats()->formatTimeUntilNextUpdate($feed, $adjustedTTL, $now, true) ?>
 			</td>
 		</tr>
 		<?php } ?>
@@ -141,23 +126,10 @@ $now = time();
 				<?= $this->getStats()->humanIntervalFromSeconds($feed->ttl) ?>
 			</td>
 			<td>
-				<?= ($feed->lastError > $feed->lastUpdate) ? 'error ' . $this->getStats()->humanIntervalFromSeconds($now - $feed->lastError) . ' ago' : (($feed->lastUpdate > 0) ? $this->getStats()->humanIntervalFromSeconds($now - $feed->lastUpdate) . ' ago' : 'never') ?>
+				<?= $this->getStats()->formatLastAttempt($feed, $now) ?>
 			</td>
 			<td>
-				<?php
-                    $lastAttempt = $feed->lastAttempt;
-                    if ($lastAttempt > 0) {
-                        $timeUntil = $lastAttempt + $feed->ttl - $now;
-                        if ($timeUntil > 0) {
-                            $interval = $this->getStats()->humanIntervalFromSeconds($timeUntil);
-                            echo $feed->lastError > $feed->lastUpdate ? $interval . ' (in error)' : $interval;
-                        } else {
-                            echo $feed->lastError > $feed->lastUpdate ? 'pending (in error)' : 'pending';
-                        }
-                    } else {
-                        echo 'never attempted';
-                    }
-		    ?>
+				<?= $this->getStats()->formatTimeUntilNextUpdate($feed, $feed->ttl, $now, false) ?>
 			</td>
 		</tr>
 		<?php } ?>

--- a/configure.phtml
+++ b/configure.phtml
@@ -89,7 +89,7 @@ $now = time();
 				<?= $this->getStats()->humanIntervalFromSeconds($adjustedTTL) ?>
 			</td>
 			<td>
-				<?= ($feed->lastUpdate > 0) ? $this->getStats()->humanIntervalFromSeconds($now - $feed->lastUpdate).' ago' : ($feed->lastError > 0 ? 'error ' . $this->getStats()->humanIntervalFromSeconds($now - $feed->lastError) . ' ago' : 'never') ?>
+				<?= ($feed->lastError > $feed->lastUpdate) ? 'error ' . $this->getStats()->humanIntervalFromSeconds($now - $feed->lastError) . ' ago' : (($feed->lastUpdate > 0) ? $this->getStats()->humanIntervalFromSeconds($now - $feed->lastUpdate) . ' ago' : 'never') ?>
 			</td>
 			<td>
 				<?php
@@ -141,20 +141,18 @@ $now = time();
 				<?= $this->getStats()->humanIntervalFromSeconds($feed->ttl) ?>
 			</td>
 			<td>
-				<?= ($feed->lastUpdate > 0) ? $this->getStats()->humanIntervalFromSeconds($now - $feed->lastUpdate).' ago' : ($feed->lastError > 0 ? 'error ' . $this->getStats()->humanIntervalFromSeconds($now - $feed->lastError) . ' ago' : 'never') ?>
+				<?= ($feed->lastError > $feed->lastUpdate) ? 'error ' . $this->getStats()->humanIntervalFromSeconds($now - $feed->lastError) . ' ago' : (($feed->lastUpdate > 0) ? $this->getStats()->humanIntervalFromSeconds($now - $feed->lastUpdate) . ' ago' : 'never') ?>
 			</td>
 			<td>
 				<?php
                     $lastAttempt = $feed->lastAttempt;
                     if ($lastAttempt > 0) {
-                        $effectiveTTL = $feed->ttl + $feed->errorJitter;
-                        $timeUntil = $lastAttempt + $effectiveTTL - $now;
-                        $jitterText = $feed->errorJitter > 0 ? ', +' . $this->getStats()->humanIntervalFromSeconds($feed->errorJitter) . ' jitter' : '';
+                        $timeUntil = $lastAttempt + $feed->ttl - $now;
                         if ($timeUntil > 0) {
                             $interval = $this->getStats()->humanIntervalFromSeconds($timeUntil);
-                            echo $feed->lastError > $feed->lastUpdate ? $interval . ' (in error' . $jitterText . ')' : $interval;
+                            echo $feed->lastError > $feed->lastUpdate ? $interval . ' (in error)' : $interval;
                         } else {
-                            echo $feed->lastError > $feed->lastUpdate ? 'pending (in error' . $jitterText . ')' : 'pending';
+                            echo $feed->lastError > $feed->lastUpdate ? 'pending (in error)' : 'pending';
                         }
                     } else {
                         echo 'never attempted';

--- a/extension.php
+++ b/extension.php
@@ -11,6 +11,10 @@ class AutoTTLExtension extends Minz_Extension
 
     private const ERROR_JITTER = 60 * 60; // 1 hour max jitter for errored feeds
 
+    // FreshRSS_Feed::lastError() legacy-returns 1 (not a real timestamp) for feeds
+    // whose error state predates the _feed.error column becoming a BIGINT timestamp.
+    public const LEGACY_ERROR_SENTINEL = 1;
+
     public int $defaultTTL;
 
     public int $maxTTL;
@@ -62,7 +66,7 @@ class AutoTTLExtension extends Minz_Extension
 
     public static function calcErrorJitter(int $feedId, int $lastUpdate, int $lastError): int
     {
-        if ($lastError <= $lastUpdate || self::ERROR_JITTER <= 0) {
+        if (!self::calcIsErroring($lastUpdate, $lastError) || self::ERROR_JITTER <= 0) {
             return 0;
         }
 
@@ -72,6 +76,29 @@ class AutoTTLExtension extends Minz_Extension
     public function getErrorJitter(FreshRSS_Feed $feed): int
     {
         return self::calcErrorJitter($feed->id(), $feed->lastUpdate(), $feed->lastError());
+    }
+
+    /*
+     * Whether the feed's most recent fetch attempt ended in an error.
+     * Guards against the legacy sentinel value of lastError(), which is not comparable to lastUpdate().
+     */
+    public static function calcIsErroring(int $lastUpdate, int $lastError): bool
+    {
+        return $lastError === self::LEGACY_ERROR_SENTINEL || $lastError > $lastUpdate;
+    }
+
+    /*
+     * Timestamp of the feed's most recent fetch attempt (success or error).
+     * Falls back to lastUpdate() when lastError() is the legacy sentinel, since
+     * its real timestamp is unknown.
+     */
+    public static function calcLastAttempt(int $lastUpdate, int $lastError): int
+    {
+        if ($lastError <= self::LEGACY_ERROR_SENTINEL) {
+            return $lastUpdate;
+        }
+
+        return max($lastUpdate, $lastError);
     }
 
     public function feedBeforeActualizeHook(FreshRSS_Feed $feed)
@@ -86,7 +113,7 @@ class AutoTTLExtension extends Minz_Extension
             return $feed;
         }
 
-        $lastAttempt = max($feed->lastUpdate(), $feed->lastError());
+        $lastAttempt = self::calcLastAttempt($feed->lastUpdate(), $feed->lastError());
         if ($lastAttempt === 0) {
             Minz_Log::debug(
                 sprintf(

--- a/extension.php
+++ b/extension.php
@@ -9,6 +9,8 @@ class AutoTTLExtension extends Minz_Extension
 
     private const STATS_COUNT = 100;
 
+    private const ERROR_JITTER = 60 * 60; // 1 hour max jitter for errored feeds
+
     public int $defaultTTL;
 
     public int $maxTTL;
@@ -58,6 +60,20 @@ class AutoTTLExtension extends Minz_Extension
         return $this->stats;
     }
 
+    public static function calcErrorJitter(int $feedId, int $lastUpdate, int $lastError): int
+    {
+        if ($lastError <= $lastUpdate || self::ERROR_JITTER <= 0) {
+            return 0;
+        }
+
+        return (int) (abs(crc32($feedId . '_' . $lastError)) % self::ERROR_JITTER);
+    }
+
+    public function getErrorJitter(FreshRSS_Feed $feed): int
+    {
+        return self::calcErrorJitter($feed->id(), $feed->lastUpdate(), $feed->lastError());
+    }
+
     public function feedBeforeActualizeHook(FreshRSS_Feed $feed)
     {
         // A direct request for one feed is a user-initiated refresh.
@@ -70,10 +86,11 @@ class AutoTTLExtension extends Minz_Extension
             return $feed;
         }
 
-        if ($feed->lastUpdate() === 0) {
+        $lastAttempt = max($feed->lastUpdate(), $feed->lastError());
+        if ($lastAttempt === 0) {
             Minz_Log::debug(
                 sprintf(
-                    'AutoTTL: feed %d (%s) never updated, updating now',
+                    'AutoTTL: feed %d (%s) never attempted, updating now',
                     $feed->id(),
                     $feed->name(),
                 )
@@ -94,18 +111,21 @@ class AutoTTLExtension extends Minz_Extension
             return $feed;
         }
 
-        $lastUpdate = $feed->lastUpdate();
-        $timeSinceLastUpdate = time() - $lastUpdate;
-        $ttl = $this->getStats()->getAdjustedTTL($feed->id(), $lastUpdate);
+        $timeSinceLastAttempt = time() - $lastAttempt;
+        $ttl = $this->getStats()->getAdjustedTTL($feed->id(), $lastAttempt);
+        $jitter = $this->getErrorJitter($feed);
+        $effectiveTTL = $ttl + $jitter;
 
-        if ($timeSinceLastUpdate < $ttl) {
+        if ($timeSinceLastAttempt < $effectiveTTL) {
             Minz_Log::debug(
                 sprintf(
-                    'AutoTTL: skip feed %d (%s, last update %s): adjusted TTL (%ds) not exceeded yet',
+                    'AutoTTL: skip feed %d (%s, last attempt %s): effective TTL (%ds = %ds TTL + %ds jitter) not exceeded yet',
                     $feed->id(),
                     $feed->name(),
-                    date('r', $feed->lastUpdate()),
+                    date('r', $lastAttempt),
+                    $effectiveTTL,
                     $ttl,
+                    $jitter,
                 )
             );
 
@@ -114,10 +134,10 @@ class AutoTTLExtension extends Minz_Extension
 
         Minz_Log::debug(
             sprintf(
-                'AutoTTL: updating feed %d (%s, last update %s, adjusted TTL %ds)',
+                'AutoTTL: updating feed %d (%s, last attempt %s, adjusted TTL %ds)',
                 $feed->id(),
                 $feed->name(),
-                date('r', $feed->lastUpdate()),
+                date('r', $lastAttempt),
                 $ttl,
             )
         );

--- a/stats.php
+++ b/stats.php
@@ -8,6 +8,12 @@ class StatItem
 
     public int $lastUpdate;
 
+    public int $lastError;
+
+    public int $lastAttempt;
+
+    public int $errorJitter;
+
     public int $ttl;
 
     public int $avgTTL;
@@ -19,6 +25,9 @@ class StatItem
         $this->id = (int) $feed['id'];
         $this->name = html_entity_decode($feed['name']);
         $this->lastUpdate = (int) $feed['lastUpdate'];
+        $this->lastError = (int) ($feed['error'] ?? 0);
+        $this->lastAttempt = max($this->lastUpdate, $this->lastError);
+        $this->errorJitter = AutoTTLExtension::calcErrorJitter($this->id, $this->lastUpdate, $this->lastError);
         $this->ttl = (int) $feed['ttl'];
         $this->avgTTL = (int) $feed['avgTTL'];
         $this->maxTTL = $maxTTL;
@@ -120,6 +129,7 @@ SELECT
     feed.id,
     feed.name,
     feed.`lastUpdate`,
+    feed.error,
     feed.ttl,
     COALESCE((feed.`lastUpdate` - MIN(stats.date)) / COUNT(1), 0) AS `avgTTL`
 FROM `_feed` AS feed

--- a/stats.php
+++ b/stats.php
@@ -12,6 +12,8 @@ class StatItem
 
     public int $lastAttempt;
 
+    public bool $isErroring;
+
     public int $errorJitter;
 
     public int $ttl;
@@ -26,7 +28,8 @@ class StatItem
         $this->name = html_entity_decode($feed['name']);
         $this->lastUpdate = (int) $feed['lastUpdate'];
         $this->lastError = (int) ($feed['error'] ?? 0);
-        $this->lastAttempt = max($this->lastUpdate, $this->lastError);
+        $this->lastAttempt = AutoTTLExtension::calcLastAttempt($this->lastUpdate, $this->lastError);
+        $this->isErroring = AutoTTLExtension::calcIsErroring($this->lastUpdate, $this->lastError);
         $this->errorJitter = AutoTTLExtension::calcErrorJitter($this->id, $this->lastUpdate, $this->lastError);
         $this->ttl = (int) $feed['ttl'];
         $this->avgTTL = (int) $feed['avgTTL'];
@@ -124,6 +127,12 @@ SQL;
             $where = 'feed.ttl != 0';
         }
 
+        // Mirrors AutoTTLExtension::calcLastAttempt(): the legacy error sentinel (1) is
+        // not a real timestamp, so it's excluded from the "last attempt" anchor used below.
+        // This must match the anchor the throttle engine uses (feedBeforeActualizeHook),
+        // otherwise the displayed adjusted TTL diverges from the one actually applied.
+        $lastAttempt = "(CASE WHEN feed.error > 1 AND feed.error > feed.`lastUpdate` THEN feed.error ELSE feed.`lastUpdate` END)";
+
         $sql = <<<SQL
 SELECT
     feed.id,
@@ -131,7 +140,7 @@ SELECT
     feed.`lastUpdate`,
     feed.error,
     feed.ttl,
-    COALESCE((feed.`lastUpdate` - MIN(stats.date)) / COUNT(1), 0) AS `avgTTL`
+    COALESCE(({$lastAttempt} - MIN(stats.date)) / COUNT(1), 0) AS `avgTTL`
 FROM `_feed` AS feed
 LEFT JOIN (
     SELECT id_feed, date
@@ -140,7 +149,7 @@ LEFT JOIN (
 ) AS stats ON feed.id = stats.id_feed
 WHERE {$where}
 GROUP BY feed.id
-ORDER BY COALESCE((feed.`lastUpdate` - MIN(stats.date)) / COUNT(1), 0) = 0, `avgTTL` ASC
+ORDER BY COALESCE(({$lastAttempt} - MIN(stats.date)) / COUNT(1), 0) = 0, `avgTTL` ASC
 LIMIT {$this->statsCount}
 SQL;
 
@@ -153,6 +162,37 @@ SQL;
         }
 
         return $list;
+    }
+
+    public function formatLastAttempt(StatItem $feed, int $now): string
+    {
+        if ($feed->isErroring) {
+            return $feed->lastError > AutoTTLExtension::LEGACY_ERROR_SENTINEL
+                ? 'error ' . $this->humanIntervalFromSeconds($now - $feed->lastError) . ' ago'
+                : 'error (time unknown)';
+        }
+
+        return $feed->lastUpdate > 0
+            ? $this->humanIntervalFromSeconds($now - $feed->lastUpdate) . ' ago'
+            : 'never';
+    }
+
+    public function formatTimeUntilNextUpdate(StatItem $feed, int $ttl, int $now, bool $includeJitter): string
+    {
+        if ($feed->lastAttempt === 0) {
+            return 'never attempted';
+        }
+
+        $jitter = $includeJitter ? $feed->errorJitter : 0;
+        $timeUntil = $feed->lastAttempt + $ttl + $jitter - $now;
+
+        $suffix = '';
+        if ($feed->isErroring) {
+            $jitterText = $jitter > 0 ? ', +' . $this->humanIntervalFromSeconds($jitter) . ' jitter' : '';
+            $suffix = ' (in error' . $jitterText . ')';
+        }
+
+        return ($timeUntil > 0 ? $this->humanIntervalFromSeconds($timeUntil) : 'pending') . $suffix;
     }
 
     private function getStatsCutoff(): int

--- a/tests/AutoTTLStatsTest.php
+++ b/tests/AutoTTLStatsTest.php
@@ -239,8 +239,9 @@ final class AutoTTLStatsTest extends TestCase
             $this->assertGreaterThanOrEqual(0, $jitter2);
             $this->assertLessThan(60 * 60, $jitter2);
 
-            // 3. Different feed IDs with the same error timestamp should yield different jitter offsets
-            $this->assertNotEquals($jitter1, $jitter2);
+            // 3. Jitter calculation should be deterministic for the same feed and error timestamp
+            $this->assertSame($jitter1, $ext->getErrorJitter($feed1Error));
+            $this->assertSame($jitter2, $ext->getErrorJitter($feed2Error));
         } finally {
             FreshRSS_feed_Controller::deleteFeed($feed1->id());
             FreshRSS_feed_Controller::deleteFeed($feed2->id());

--- a/tests/AutoTTLStatsTest.php
+++ b/tests/AutoTTLStatsTest.php
@@ -239,6 +239,9 @@ final class AutoTTLStatsTest extends TestCase
             $this->assertGreaterThanOrEqual(0, $jitter2);
             $this->assertLessThan(60 * 60, $jitter2);
 
+            // Jitter is per-feed, so two feeds erroring at the same instant must be staggered.
+            $this->assertNotSame($jitter1, $jitter2);
+
             // 3. Jitter calculation should be deterministic for the same feed and error timestamp
             $this->assertSame($jitter1, $ext->getErrorJitter($feed1Error));
             $this->assertSame($jitter2, $ext->getErrorJitter($feed2Error));

--- a/tests/AutoTTLStatsTest.php
+++ b/tests/AutoTTLStatsTest.php
@@ -133,4 +133,117 @@ final class AutoTTLStatsTest extends TestCase
             FreshRSS_feed_Controller::deleteFeed($feed->id());
         }
     }
+
+    public function test_stat_item_last_attempt(): void
+    {
+        $item1 = new StatItem([
+            'id' => 1,
+            'name' => 'Test Feed',
+            'lastUpdate' => 1000,
+            'error' => 500,
+            'ttl' => 0,
+            'avgTTL' => 3600,
+        ], 86400);
+
+        $this->assertSame(1000, $item1->lastUpdate);
+        $this->assertSame(500, $item1->lastError);
+        $this->assertSame(1000, $item1->lastAttempt);
+        $this->assertSame(0, $item1->errorJitter);
+
+        $item2 = new StatItem([
+            'id' => 2,
+            'name' => 'Errored Feed',
+            'lastUpdate' => 1000,
+            'error' => 2000,
+            'ttl' => 0,
+            'avgTTL' => 3600,
+        ], 86400);
+
+        $this->assertSame(1000, $item2->lastUpdate);
+        $this->assertSame(2000, $item2->lastError);
+        $this->assertSame(2000, $item2->lastAttempt);
+        $this->assertGreaterThanOrEqual(0, $item2->errorJitter);
+        $this->assertLessThan(60 * 60, $item2->errorJitter);
+    }
+
+    public function test_feed_before_actualize_throttles_recent_error(): void
+    {
+        try {
+            $feed = FreshRSS_feed_Controller::addFeed('http://wiremock:8080/three_per_day.xml');
+
+            $metaInfo = json_decode((string) file_get_contents(dirname(__DIR__) . '/metadata.json'), true);
+            $metaInfo['path'] = dirname(__DIR__);
+            $ext = new AutoTTLExtension($metaInfo);
+            $ext->init();
+            $ext->maxTTL = 3600;
+
+            // Set lastUpdate to 1 day ago so lastError takes precedence in max(lastUpdate, lastError)
+            $now = time();
+            $feedDAO = FreshRSS_Factory::createFeedDao();
+            $feedDAO->updateLastUpdate($feed->id(), $now - 86400);
+
+            // Simulate an error 10 minutes ago
+            $feedDAO->updateLastError($feed->id(), $now - 600);
+            $feed = $feedDAO->searchById($feed->id());
+
+            // Since last error was 10 minutes ago, and TTL is 3600 (1 hour),
+            // feedBeforeActualizeHook should return null (throttle feed)
+            $result = $ext->feedBeforeActualizeHook($feed);
+            $this->assertNull($result);
+
+            // If error was 2 hours ago (7200s > 3600s maxTTL), feedBeforeActualizeHook should return $feed
+            $feedDAO->updateLastError($feed->id(), $now - 7200);
+            $feed = $feedDAO->searchById($feed->id());
+            $result = $ext->feedBeforeActualizeHook($feed);
+            $this->assertNotNull($result);
+            $this->assertSame($feed->id(), $result->id());
+        } finally {
+            FreshRSS_feed_Controller::deleteFeed($feed->id());
+        }
+    }
+
+    public function test_error_jitter_staggers_errored_feeds(): void
+    {
+        try {
+            $feed1 = FreshRSS_feed_Controller::addFeed('http://wiremock:8080/three_per_day.xml');
+            $feed2 = FreshRSS_feed_Controller::addFeed('http://wiremock:8080/two_close.xml');
+
+            $metaInfo = json_decode((string) file_get_contents(dirname(__DIR__) . '/metadata.json'), true);
+            $metaInfo['path'] = dirname(__DIR__);
+            $ext = new AutoTTLExtension($metaInfo);
+            $ext->init();
+
+            $now = time();
+            $feedDAO = FreshRSS_Factory::createFeedDao();
+            $feedDAO->updateLastUpdate($feed1->id(), $now - 86400);
+            $feedDAO->updateLastUpdate($feed2->id(), $now - 86400);
+
+            // 1. Non-errored feed should return 0 jitter
+            $feed1Clean = $feedDAO->searchById($feed1->id());
+            $this->assertSame(0, $ext->getErrorJitter($feed1Clean));
+
+            // 2. Errored feeds should return non-negative jitter within 0..3599 seconds (1 hour)
+            $errorTime = $now - 600;
+            $feedDAO->updateLastError($feed1->id(), $errorTime);
+            $feedDAO->updateLastError($feed2->id(), $errorTime);
+
+            $feed1Error = $feedDAO->searchById($feed1->id());
+            $feed2Error = $feedDAO->searchById($feed2->id());
+
+            $jitter1 = $ext->getErrorJitter($feed1Error);
+            $jitter2 = $ext->getErrorJitter($feed2Error);
+
+            $this->assertGreaterThanOrEqual(0, $jitter1);
+            $this->assertLessThan(60 * 60, $jitter1);
+
+            $this->assertGreaterThanOrEqual(0, $jitter2);
+            $this->assertLessThan(60 * 60, $jitter2);
+
+            // 3. Different feed IDs with the same error timestamp should yield different jitter offsets
+            $this->assertNotEquals($jitter1, $jitter2);
+        } finally {
+            FreshRSS_feed_Controller::deleteFeed($feed1->id());
+            FreshRSS_feed_Controller::deleteFeed($feed2->id());
+        }
+    }
 }


### PR DESCRIPTION
- Use max(lastUpdate, lastError) as the last attempt timestamp in feedBeforeActualizeHook to throttle errored feeds by their adjusted TTL.
- Apply a deterministic hash-based error jitter (0 to 1 hour) for errored feeds to stagger retries across cron passes and prevent same-domain rate limiting.
- Expose lastError, lastAttempt, and errorJitter on StatItem and render inline error jitter badges in the configure.phtml statistics view.
- Add unit tests for StatItem lastAttempt calculation, feed error throttling, and 1h error jitter staggering.

Related: https://github.com/mgnsk/FreshRSS-AutoTTL/issues/29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feed status now reports recent errors when no successful update is available.
  * Refresh scheduling accounts for the latest attempt and applies deterministic timing variation after errors.
  * Feed states now distinguish pending, errored, and never-attempted conditions.
  * Status displays include error timing and jitter details.

* **Bug Fixes**
  * Feeds that recently failed are no longer refreshed prematurely.
  * Feeds with errors are correctly recognized as having been attempted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->