### PR TITLE
Fix flaky error jitter stagger test

### DIFF
--- a/tests/AutoTTLStatsTest.php
+++ b/tests/AutoTTLStatsTest.php
@@ -239,8 +239,15 @@ final class AutoTTLStatsTest extends TestCase
             $this->assertGreaterThanOrEqual(0, $jitter2);
             $this->assertLessThan(60 * 60, $jitter2);
 
-            // Jitter is per-feed, so two feeds erroring at the same instant must be staggered.
-            $this->assertNotSame($jitter1, $jitter2);
+            // Jitter is per-feed, so feeds erroring at the same instant should generally be
+            // staggered. Any two specific feed IDs have a 1-in-3600 chance of colliding on the
+            // same jitter bucket, so assert the stagger property across many synthetic feed IDs
+            // instead of just $feed1/$feed2, which would make the test flaky.
+            $jitters = [];
+            for ($syntheticFeedId = 1; $syntheticFeedId <= 20; $syntheticFeedId++) {
+                $jitters[] = AutoTTLExtension::calcErrorJitter($syntheticFeedId, $now - 86400, $errorTime);
+            }
+            $this->assertGreaterThan(1, count(array_unique($jitters)), 'Expected jitter to vary across feeds');
 
             // 3. Jitter calculation should be deterministic for the same feed and error timestamp
             $this->assertSame($jitter1, $ext->getErrorJitter($feed1Error));


### PR DESCRIPTION
getErrorJitter hashes feedId+lastError into a 0..3599 bucket, so any two specific feed IDs have a real ~1/3600 chance of landing in the same bucket. Asserting jitter1 != jitter2 for exactly two feeds was bound to fail occasionally. Assert the stagger property across many synthetic feed IDs instead, which keeps the intent but eliminates the false-failure rate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved jitter testing to validate varied, deterministic values across multiple feed IDs.
  * Retained checks ensuring jitter values remain within expected bounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->