### PR TITLE
Add exponential backoff for errored feeds, jitter proportional to TTL

### DIFF
--- a/configure.phtml
+++ b/configure.phtml
@@ -76,7 +76,6 @@ $now = time();
 		</thead>
 		<tbody>
 		<?php foreach ($feedsUsingAutoTTL as $feed) { ?>
-		<?php $adjustedTTL = $this->getStats()->calcAdjustedTTL($feed->avgTTL); ?>
 		<tr>
 			<td>
 				<a class="configure" target="_blank" href="<?= _url('subscription', 'feed', 'id', $feed->id) ?>" title="<?= _t('gen.action.manage') ?>"><?= _i('configure') ?></a>
@@ -86,13 +85,13 @@ $now = time();
 				<?= ($feed->avgTTL > 0) ? $this->getStats()->humanIntervalFromSeconds($feed->avgTTL) : 'not enough data' ?>
 			</td>
 			<td>
-				<?= $this->getStats()->humanIntervalFromSeconds($adjustedTTL) ?>
+				<?= $this->getStats()->humanIntervalFromSeconds($feed->backoffTTL) ?>
 			</td>
 			<td>
 				<?= $this->getStats()->formatLastAttempt($feed, $now) ?>
 			</td>
 			<td>
-				<?= $this->getStats()->formatTimeUntilNextUpdate($feed, $adjustedTTL, $now, true) ?>
+				<?= $this->getStats()->formatTimeUntilNextUpdate($feed, $feed->backoffTTL, $now, true) ?>
 			</td>
 		</tr>
 		<?php } ?>

--- a/extension.php
+++ b/extension.php
@@ -135,7 +135,7 @@ class AutoTTLExtension extends Minz_Extension
 
         Minz_Log::debug(
             sprintf(
-                'AutoTTL: updating feed %d (%s, last attempt %s, adjusted TTL %ds)',
+                'AutoTTL: updating feed %d (%s, last attempt %s, backoff TTL %ds)',
                 $feed->id(),
                 $feed->name(),
                 date('r', $lastAttempt),

--- a/extension.php
+++ b/extension.php
@@ -9,17 +9,11 @@ class AutoTTLExtension extends Minz_Extension
 
     private const STATS_COUNT = 100;
 
-    // Not currently user-configurable, but shaped as if it could be:
-    // threaded through as a value rather than hardcoded where it's used.
-    private const ERROR_JITTER = 60 * 60; // 1 hour max jitter for errored feeds
-
     public int $defaultTTL;
 
     public int $maxTTL;
 
     public int $statsCount;
-
-    public int $errorJitterMax;
 
     /**
      * @var AutoTTLStats
@@ -39,7 +33,6 @@ class AutoTTLExtension extends Minz_Extension
         $this->defaultTTL = FreshRSS_Context::userConf()->attributeInt('ttl_default') ?? FreshRSS_Feed::TTL_DEFAULT;
         $this->maxTTL = FreshRSS_Context::userConf()->attributeInt('auto_ttl_max_ttl') ?? self::MAX_TTL;
         $this->statsCount = FreshRSS_Context::userConf()->attributeInt('auto_ttl_stats_count') ?? self::STATS_COUNT;
-        $this->errorJitterMax = self::ERROR_JITTER;
     }
 
     /*
@@ -59,15 +52,25 @@ class AutoTTLExtension extends Minz_Extension
     public function getStats(): AutoTTLStats
     {
         if ($this->stats === null) {
-            $this->stats = new AutoTTLStats($this->defaultTTL, $this->maxTTL, $this->statsCount, $this->errorJitterMax);
+            $this->stats = new AutoTTLStats($this->defaultTTL, $this->maxTTL, $this->statsCount);
         }
 
         return $this->stats;
     }
 
-    public function getErrorJitter(FreshRSS_Feed $feed): int
+    public function getBackoffTTL(FreshRSS_Feed $feed, int $baseTTL): int
     {
-        return StatItem::calcErrorJitter($feed->id(), $feed->lastUpdate(), $feed->lastError(), $this->errorJitterMax);
+        $lastAttempt = StatItem::calcLastAttempt($feed->lastUpdate(), $feed->lastError());
+        $isErroring = StatItem::calcIsErroring($feed->lastUpdate(), $feed->lastError());
+
+        return StatItem::calcBackoffTTL($baseTTL, $feed->lastUpdate(), $lastAttempt, $isErroring, $this->maxTTL);
+    }
+
+    public function getErrorJitter(FreshRSS_Feed $feed, int $backoffTTL): int
+    {
+        $isErroring = StatItem::calcIsErroring($feed->lastUpdate(), $feed->lastError());
+
+        return StatItem::calcErrorJitter($feed->id(), $backoffTTL, $feed->lastError(), $isErroring);
     }
 
     public function feedBeforeActualizeHook(FreshRSS_Feed $feed)
@@ -109,18 +112,20 @@ class AutoTTLExtension extends Minz_Extension
 
         $timeSinceLastAttempt = time() - $lastAttempt;
         $ttl = $this->getStats()->getAdjustedTTL($feed->id(), $lastAttempt);
-        $jitter = $this->getErrorJitter($feed);
-        $effectiveTTL = $ttl + $jitter;
+        $backoffTTL = $this->getBackoffTTL($feed, $ttl);
+        $jitter = $this->getErrorJitter($feed, $backoffTTL);
+        $effectiveTTL = $backoffTTL + $jitter;
 
         if ($timeSinceLastAttempt < $effectiveTTL) {
             Minz_Log::debug(
                 sprintf(
-                    'AutoTTL: skip feed %d (%s, last attempt %s): effective TTL (%ds = %ds TTL + %ds jitter) not exceeded yet',
+                    'AutoTTL: skip feed %d (%s, last attempt %s): effective TTL (%ds = %ds TTL + %ds backoff + %ds jitter) not exceeded yet',
                     $feed->id(),
                     $feed->name(),
                     date('r', $lastAttempt),
                     $effectiveTTL,
                     $ttl,
+                    $backoffTTL - $ttl,
                     $jitter,
                 )
             );
@@ -134,7 +139,7 @@ class AutoTTLExtension extends Minz_Extension
                 $feed->id(),
                 $feed->name(),
                 date('r', $lastAttempt),
-                $ttl,
+                $backoffTTL,
             )
         );
 

--- a/stats.php
+++ b/stats.php
@@ -6,6 +6,10 @@ class StatItem
     // whose error state predates the _feed.error column becoming a BIGINT timestamp.
     public const LEGACY_ERROR_SENTINEL = 1;
 
+    // Jitter is a fraction of backoffTTL rather than an absolute value, so it scales
+    // with the wait instead of dwarfing short TTLs or being negligible on long ones.
+    public const JITTER_FRACTION = 0.25;
+
     public int $id;
 
     public string $name;
@@ -18,13 +22,15 @@ class StatItem
 
     public bool $isErroring;
 
+    public int $backoffTTL;
+
     public int $errorJitter;
 
     public int $ttl;
 
     public int $avgTTL;
 
-    public function __construct(array $feed, int $errorJitterMax)
+    public function __construct(array $feed, int $baseTTL, int $maxTTL)
     {
         $this->id = (int) $feed['id'];
         $this->name = html_entity_decode($feed['name']);
@@ -32,18 +38,24 @@ class StatItem
         $this->lastError = (int) ($feed['error'] ?? 0);
         $this->lastAttempt = self::calcLastAttempt($this->lastUpdate, $this->lastError);
         $this->isErroring = self::calcIsErroring($this->lastUpdate, $this->lastError);
-        $this->errorJitter = self::calcErrorJitter($this->id, $this->lastUpdate, $this->lastError, $errorJitterMax);
+        $this->backoffTTL = self::calcBackoffTTL($baseTTL, $this->lastUpdate, $this->lastAttempt, $this->isErroring, $maxTTL);
+        $this->errorJitter = self::calcErrorJitter($this->id, $this->backoffTTL, $this->lastError, $this->isErroring);
         $this->ttl = (int) $feed['ttl'];
         $this->avgTTL = (int) $feed['avgTTL'];
     }
 
-    public static function calcErrorJitter(int $feedId, int $lastUpdate, int $lastError, int $errorJitterMax): int
+    public static function calcErrorJitter(int $feedId, int $backoffTTL, int $lastError, bool $isErroring): int
     {
-        if (!self::calcIsErroring($lastUpdate, $lastError) || $errorJitterMax <= 0) {
+        if (!$isErroring) {
             return 0;
         }
 
-        return (int) (abs(crc32($feedId . '_' . $lastError)) % $errorJitterMax);
+        $jitterMax = (int) ($backoffTTL * self::JITTER_FRACTION);
+        if ($jitterMax <= 0) {
+            return 0;
+        }
+
+        return (int) (abs(crc32($feedId . '_' . $lastError)) % $jitterMax);
     }
 
     /*
@@ -67,6 +79,28 @@ class StatItem
         }
 
         return max($lastUpdate, $lastError);
+    }
+
+    /*
+     * TTL to apply to a feed that keeps erroring, growing with how long it's been
+     * failing (lastAttempt - lastUpdate). Since each retry only happens after
+     * waiting backoffTTL, errorAge roughly doubles each pass once it exceeds
+     * baseTTL, producing exponential backoff bounded by maxTTL without needing
+     * to persist an attempt counter.
+     *
+     * Never returns less than baseTTL, even if baseTTL itself exceeds maxTTL
+     * (calcAdjustedTTL's defaultTTL > maxTTL escape hatch) - an errored feed
+     * must never be checked more eagerly than a healthy one.
+     */
+    public static function calcBackoffTTL(int $baseTTL, int $lastUpdate, int $lastAttempt, bool $isErroring, int $maxTTL): int
+    {
+        if (!$isErroring) {
+            return $baseTTL;
+        }
+
+        $errorAge = $lastAttempt - $lastUpdate;
+
+        return max($baseTTL, min($maxTTL, max($baseTTL, $errorAge)));
     }
 }
 
@@ -101,23 +135,17 @@ class AutoTTLStats extends Minz_ModelPdo
     private $statsCount;
 
     /**
-     * @var int
-     */
-    private $errorJitterMax;
-
-    /**
      * @var TimeSource
      */
     private $timeSource;
 
-    public function __construct(int $defaultTTL, int $maxTTL, int $statsCount, int $errorJitterMax)
+    public function __construct(int $defaultTTL, int $maxTTL, int $statsCount)
     {
         parent::__construct();
 
         $this->defaultTTL = $defaultTTL;
         $this->maxTTL = $maxTTL;
         $this->statsCount = $statsCount;
-        $this->errorJitterMax = $errorJitterMax;
         $this->timeSource = new DefaultTime();
     }
 
@@ -196,7 +224,8 @@ SQL;
 
         $list = [];
         foreach ($res as $feed) {
-            $list[] = new StatItem($feed, $this->errorJitterMax);
+            $baseTTL = $this->calcAdjustedTTL((int) $feed['avgTTL']);
+            $list[] = new StatItem($feed, $baseTTL, $this->maxTTL);
         }
 
         return $list;

--- a/tests/AutoTTLStatsTest.php
+++ b/tests/AutoTTLStatsTest.php
@@ -38,7 +38,7 @@ final class AutoTTLStatsTest extends TestCase
         $defaultTTL = 3600;
         $maxTTL = 3599;
 
-        $stats = new AutoTTLStats($defaultTTL, $maxTTL, 100, 3600);
+        $stats = new AutoTTLStats($defaultTTL, $maxTTL, 100);
         $adjustedTTL = $stats->calcAdjustedTTL(1);
 
         // defaultTTL returned.
@@ -50,7 +50,7 @@ final class AutoTTLStatsTest extends TestCase
         $defaultTTL = 3600;
         $maxTTL = 86400;
 
-        $stats = new AutoTTLStats($defaultTTL, $maxTTL, 100, 3600);
+        $stats = new AutoTTLStats($defaultTTL, $maxTTL, 100);
         $adjustedTTL = $stats->calcAdjustedTTL(0);
 
         // maxTTL returned.
@@ -62,7 +62,7 @@ final class AutoTTLStatsTest extends TestCase
         $defaultTTL = 3600;
         $maxTTL = 86400;
 
-        $stats = new AutoTTLStats($defaultTTL, $maxTTL, 100, 3600);
+        $stats = new AutoTTLStats($defaultTTL, $maxTTL, 100);
         $adjustedTTL = $stats->calcAdjustedTTL($maxTTL + 1);
 
         // maxTTL returned.
@@ -74,7 +74,7 @@ final class AutoTTLStatsTest extends TestCase
         $defaultTTL = 3600;
         $maxTTL = 86400;
 
-        $stats = new AutoTTLStats($defaultTTL, $maxTTL, 100, 3600);
+        $stats = new AutoTTLStats($defaultTTL, $maxTTL, 100);
         $adjustedTTL = $stats->calcAdjustedTTL($defaultTTL - 1);
 
         // defaultTTL returned.
@@ -90,7 +90,7 @@ final class AutoTTLStatsTest extends TestCase
         try {
             $feed = FreshRSS_feed_Controller::addFeed('http://wiremock:8080/three_per_day.xml');
 
-            $stats = new AutoTTLStats($defaultTTL, $maxTTL, 100, 3600);
+            $stats = new AutoTTLStats($defaultTTL, $maxTTL, 100);
             $stats->setTimeSource(new MockTime(strtotime("2000-01-02T00:00:00Z")));
             $adjustedTTL = $stats->getAdjustedTTL($feed->id(), strtotime("2000-01-01T16:00:00Z"));
 
@@ -112,7 +112,7 @@ final class AutoTTLStatsTest extends TestCase
         try {
             $feed = FreshRSS_feed_Controller::addFeed('http://wiremock:8080/two_close.xml');
 
-            $stats = new AutoTTLStats($defaultTTL, $maxTTL, 100, 3600);
+            $stats = new AutoTTLStats($defaultTTL, $maxTTL, 100);
             $stats->setTimeSource(new MockTime(strtotime("2000-01-04T00:00:00Z")));
 
             // Two updates in a row when we checked implies frequent updates.
@@ -140,6 +140,9 @@ final class AutoTTLStatsTest extends TestCase
 
     public function test_stat_item_last_attempt(): void
     {
+        $baseTTL = 3600;
+        $maxTTL = 86400;
+
         $item1 = new StatItem([
             'id' => 1,
             'name' => 'Test Feed',
@@ -147,13 +150,16 @@ final class AutoTTLStatsTest extends TestCase
             'error' => 500,
             'ttl' => 0,
             'avgTTL' => 3600,
-        ], 3600);
+        ], $baseTTL, $maxTTL);
 
         $this->assertSame(1000, $item1->lastUpdate);
         $this->assertSame(500, $item1->lastError);
         $this->assertSame(1000, $item1->lastAttempt);
+        $this->assertFalse($item1->isErroring);
+        $this->assertSame($baseTTL, $item1->backoffTTL);
         $this->assertSame(0, $item1->errorJitter);
 
+        // errorAge (1000s) below baseTTL (3600s): backoff stays at baseTTL.
         $item2 = new StatItem([
             'id' => 2,
             'name' => 'Errored Feed',
@@ -161,13 +167,83 @@ final class AutoTTLStatsTest extends TestCase
             'error' => 2000,
             'ttl' => 0,
             'avgTTL' => 3600,
-        ], 3600);
+        ], $baseTTL, $maxTTL);
 
         $this->assertSame(1000, $item2->lastUpdate);
         $this->assertSame(2000, $item2->lastError);
         $this->assertSame(2000, $item2->lastAttempt);
+        $this->assertTrue($item2->isErroring);
+        $this->assertSame($baseTTL, $item2->backoffTTL);
         $this->assertGreaterThanOrEqual(0, $item2->errorJitter);
-        $this->assertLessThan(60 * 60, $item2->errorJitter);
+        $this->assertLessThan((int) ($baseTTL * StatItem::JITTER_FRACTION), $item2->errorJitter);
+
+        // errorAge (7200s) above baseTTL: backoff grows to match errorAge.
+        $item3 = new StatItem([
+            'id' => 3,
+            'name' => 'Long Errored Feed',
+            'lastUpdate' => 1000,
+            'error' => 8200,
+            'ttl' => 0,
+            'avgTTL' => 3600,
+        ], $baseTTL, $maxTTL);
+
+        $this->assertSame(7200, $item3->backoffTTL);
+        $this->assertLessThan((int) (7200 * StatItem::JITTER_FRACTION), $item3->errorJitter);
+
+        // errorAge far exceeding maxTTL: backoff clamps at maxTTL.
+        $item4 = new StatItem([
+            'id' => 4,
+            'name' => 'Deeply Errored Feed',
+            'lastUpdate' => 1000,
+            'error' => 1000 + 200000,
+            'ttl' => 0,
+            'avgTTL' => 3600,
+        ], $baseTTL, $maxTTL);
+
+        $this->assertSame($maxTTL, $item4->backoffTTL);
+    }
+
+    public function test_calc_backoff_ttl_grows_and_clamps(): void
+    {
+        $baseTTL = 3600;
+        $maxTTL = 86400;
+        $lastUpdate = 0;
+
+        // Not erroring: backoff is always just baseTTL.
+        $this->assertSame($baseTTL, StatItem::calcBackoffTTL($baseTTL, $lastUpdate, 100000, false, $maxTTL));
+
+        // errorAge below baseTTL: clamped up to baseTTL.
+        $this->assertSame($baseTTL, StatItem::calcBackoffTTL($baseTTL, $lastUpdate, 1800, true, $maxTTL));
+
+        // Simulate consecutive throttled retries: each retry only happens after
+        // waiting the previous backoffTTL, so errorAge grows by that amount each
+        // pass. Once past baseTTL, this produces roughly-doubling backoff.
+        $errorAge = $baseTTL;
+        $backoffs = [];
+        for ($i = 0; $i < 5; $i++) {
+            $backoff = StatItem::calcBackoffTTL($baseTTL, $lastUpdate, $errorAge, true, $maxTTL);
+            $backoffs[] = $backoff;
+            $errorAge += $backoff;
+        }
+
+        $this->assertSame([3600, 7200, 14400, 28800, 57600], $backoffs);
+
+        // Clamped at maxTTL however large errorAge grows.
+        $this->assertSame($maxTTL, StatItem::calcBackoffTTL($baseTTL, $lastUpdate, $maxTTL * 10, true, $maxTTL));
+    }
+
+    public function test_calc_backoff_ttl_never_below_base_ttl_when_base_exceeds_max(): void
+    {
+        // Mirrors calcAdjustedTTL's defaultTTL > maxTTL escape hatch (see
+        // test_default_ttl_gt_max_ttl): baseTTL can legitimately exceed maxTTL.
+        // An errored feed must still never be checked more eagerly than a
+        // healthy one, so backoff must not collapse down to maxTTL here.
+        $baseTTL = 7200;
+        $maxTTL = 3600;
+        $lastUpdate = 0;
+
+        $this->assertSame($baseTTL, StatItem::calcBackoffTTL($baseTTL, $lastUpdate, 100, true, $maxTTL));
+        $this->assertSame($baseTTL, StatItem::calcBackoffTTL($baseTTL, $lastUpdate, $baseTTL * 10, true, $maxTTL));
     }
 
     public function test_feed_before_actualize_throttles_recent_error(): void
@@ -227,11 +303,14 @@ final class AutoTTLStatsTest extends TestCase
             $feedDAO->updateLastUpdate($feed1->id(), $now - 86400);
             $feedDAO->updateLastUpdate($feed2->id(), $now - 86400);
 
+            $baseTTL = 3600;
+
             // 1. Non-errored feed should return 0 jitter
             $feed1Clean = $feedDAO->searchById($feed1->id());
-            $this->assertSame(0, $ext->getErrorJitter($feed1Clean));
+            $backoffClean = $ext->getBackoffTTL($feed1Clean, $baseTTL);
+            $this->assertSame(0, $ext->getErrorJitter($feed1Clean, $backoffClean));
 
-            // 2. Errored feeds should return non-negative jitter within 0..3599 seconds (1 hour)
+            // 2. Errored feeds should return non-negative jitter within [0, 25% of backoffTTL)
             $errorTime = $now - 600;
             $feedDAO->updateLastError($feed1->id(), $errorTime);
             $feedDAO->updateLastError($feed2->id(), $errorTime);
@@ -239,28 +318,31 @@ final class AutoTTLStatsTest extends TestCase
             $feed1Error = $feedDAO->searchById($feed1->id());
             $feed2Error = $feedDAO->searchById($feed2->id());
 
-            $jitter1 = $ext->getErrorJitter($feed1Error);
-            $jitter2 = $ext->getErrorJitter($feed2Error);
+            $backoff1 = $ext->getBackoffTTL($feed1Error, $baseTTL);
+            $backoff2 = $ext->getBackoffTTL($feed2Error, $baseTTL);
+
+            $jitter1 = $ext->getErrorJitter($feed1Error, $backoff1);
+            $jitter2 = $ext->getErrorJitter($feed2Error, $backoff2);
 
             $this->assertGreaterThanOrEqual(0, $jitter1);
-            $this->assertLessThan(60 * 60, $jitter1);
+            $this->assertLessThan((int) ($backoff1 * StatItem::JITTER_FRACTION), $jitter1);
 
             $this->assertGreaterThanOrEqual(0, $jitter2);
-            $this->assertLessThan(60 * 60, $jitter2);
+            $this->assertLessThan((int) ($backoff2 * StatItem::JITTER_FRACTION), $jitter2);
 
             // Jitter is per-feed, so feeds erroring at the same instant should generally be
-            // staggered. Any two specific feed IDs have a 1-in-3600 chance of colliding on the
+            // staggered. Any two specific feed IDs have a low chance of colliding on the
             // same jitter bucket, so assert the stagger property across many synthetic feed IDs
             // instead of just $feed1/$feed2, which would make the test flaky.
             $jitters = [];
             for ($syntheticFeedId = 1; $syntheticFeedId <= 20; $syntheticFeedId++) {
-                $jitters[] = StatItem::calcErrorJitter($syntheticFeedId, $now - 86400, $errorTime, 3600);
+                $jitters[] = StatItem::calcErrorJitter($syntheticFeedId, $baseTTL, $errorTime, true);
             }
             $this->assertGreaterThan(1, count(array_unique($jitters)), 'Expected jitter to vary across feeds');
 
             // 3. Jitter calculation should be deterministic for the same feed and error timestamp
-            $this->assertSame($jitter1, $ext->getErrorJitter($feed1Error));
-            $this->assertSame($jitter2, $ext->getErrorJitter($feed2Error));
+            $this->assertSame($jitter1, $ext->getErrorJitter($feed1Error, $backoff1));
+            $this->assertSame($jitter2, $ext->getErrorJitter($feed2Error, $backoff2));
         } finally {
             if ($feed1 !== null) {
                 FreshRSS_feed_Controller::deleteFeed($feed1->id());


### PR DESCRIPTION
Errored feeds now back off using max(baseTTL, lastError - lastUpdate), capped at maxTTL when baseTTL doesn't already exceed it. Since each retry only fires after waiting the previous backoff, this self-doubles across consecutive failures without persisting an attempt counter, using timestamps FreshRSS already stores.

Error jitter is now a fraction of the computed backoff TTL instead of a flat absolute value, so it scales sensibly whether the backoff is 20 minutes or a day, and no longer needs its own separate constant. Jitter is still added on top of the (possibly maxTTL-capped) backoff, so the effective wait can exceed maxTTL by up to 25%, same as the existing flat-jitter behavior it replaces. The jitter hash includes the feed ID, so feeds on the same domain that error at the same instant (e.g. simultaneous rate-limiting) still get different jitter values and stagger their retries instead of hammering the domain again in lockstep.

Fixes #29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved automatic feed update timing with history-based backoff.
  * Adjusted TTL displays and next-update estimates now reflect each feed’s calculated backoff.
  * Error retry delays now include proportional jitter based on the backoff duration.
  * Backoff values remain within configured minimum and maximum limits.

* **Bug Fixes**
  * Prevented calculated backoff from falling below the feed’s base TTL, including when limits conflict.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->