### PR TITLE
Show error backoff TTL separately from the base adjusted TTL in stats

### DIFF
--- a/configure.phtml
+++ b/configure.phtml
@@ -71,6 +71,7 @@ $now = time();
 			<th>Feed</th>
 			<th>Average TTL in last 30d</th>
 			<th>Adjusted update TTL</th>
+			<th>Error backoff TTL</th>
 			<th>Last update</th>
 			<th>Time until next update</th>
 		</thead>
@@ -85,7 +86,10 @@ $now = time();
 				<?= ($feed->avgTTL > 0) ? $this->getStats()->humanIntervalFromSeconds($feed->avgTTL) : 'not enough data' ?>
 			</td>
 			<td>
-				<?= $this->getStats()->humanIntervalFromSeconds($feed->backoffTTL) ?>
+				<?= $this->getStats()->humanIntervalFromSeconds($feed->baseTTL) ?>
+			</td>
+			<td>
+				<?= $feed->isErroring ? $this->getStats()->humanIntervalFromSeconds($feed->backoffTTL) : '—' ?>
 			</td>
 			<td>
 				<?= $this->getStats()->formatLastAttempt($feed, $now) ?>

--- a/stats.php
+++ b/stats.php
@@ -22,6 +22,8 @@ class StatItem
 
     public bool $isErroring;
 
+    public int $baseTTL;
+
     public int $backoffTTL;
 
     public int $errorJitter;
@@ -38,6 +40,7 @@ class StatItem
         $this->lastError = (int) ($feed['error'] ?? 0);
         $this->lastAttempt = self::calcLastAttempt($this->lastUpdate, $this->lastError);
         $this->isErroring = self::calcIsErroring($this->lastUpdate, $this->lastError);
+        $this->baseTTL = $baseTTL;
         $this->backoffTTL = self::calcBackoffTTL($baseTTL, $this->lastUpdate, $this->lastAttempt, $this->isErroring, $maxTTL);
         $this->errorJitter = self::calcErrorJitter($this->id, $this->backoffTTL, $this->lastError, $this->isErroring);
         $this->ttl = (int) $feed['ttl'];

--- a/tests/AutoTTLStatsTest.php
+++ b/tests/AutoTTLStatsTest.php
@@ -156,6 +156,7 @@ final class AutoTTLStatsTest extends TestCase
         $this->assertSame(500, $item1->lastError);
         $this->assertSame(1000, $item1->lastAttempt);
         $this->assertFalse($item1->isErroring);
+        $this->assertSame($baseTTL, $item1->baseTTL);
         $this->assertSame($baseTTL, $item1->backoffTTL);
         $this->assertSame(0, $item1->errorJitter);
 
@@ -173,6 +174,7 @@ final class AutoTTLStatsTest extends TestCase
         $this->assertSame(2000, $item2->lastError);
         $this->assertSame(2000, $item2->lastAttempt);
         $this->assertTrue($item2->isErroring);
+        $this->assertSame($baseTTL, $item2->baseTTL);
         $this->assertSame($baseTTL, $item2->backoffTTL);
         $this->assertGreaterThanOrEqual(0, $item2->errorJitter);
         $this->assertLessThan((int) ($baseTTL * StatItem::JITTER_FRACTION), $item2->errorJitter);
@@ -187,6 +189,7 @@ final class AutoTTLStatsTest extends TestCase
             'avgTTL' => 3600,
         ], $baseTTL, $maxTTL);
 
+        $this->assertSame($baseTTL, $item3->baseTTL);
         $this->assertSame(7200, $item3->backoffTTL);
         $this->assertLessThan((int) (7200 * StatItem::JITTER_FRACTION), $item3->errorJitter);
 


### PR DESCRIPTION
"Adjusted update TTL" was showing backoffTTL, which is indistinguishable from the base avg-derived TTL until backoff has grown substantially - e.g. a feed erroring for only a few minutes shows almost the same number as a healthy feed, hiding that backoff is active at all.

StatItem now also exposes baseTTL (the pre-backoff value) so the table can show it next to a new "Error backoff TTL" column, which is blank for healthy feeds and shows the actual backed-off wait for erroring ones.