### PR TITLE
Fix fatal error on configure page

### DIFF
--- a/stats.php
+++ b/stats.php
@@ -182,9 +182,17 @@ WHERE id_feed = {$feedID} AND date > {$this->getStatsCutoff()}
 SQL;
 
         $stm = $this->pdo->query($sql);
-        $res = $stm->fetch(PDO::FETCH_NAMED);
+        if ($stm !== false) {
+            $res = $stm->fetch(PDO::FETCH_NAMED);
+            if ($res !== false) {
+                return $this->calcAdjustedTTL((int) $res['avgTTL']);
+            }
+        }
 
-        return $this->calcAdjustedTTL((int) $res['avgTTL']);
+        $info = $stm === false ? $this->pdo->errorInfo() : $stm->errorInfo();
+        Minz_Log::error('AutoTTL SQL error ' . __METHOD__ . ' ' . json_encode($info));
+
+        return $this->calcAdjustedTTL(0);
     }
 
     public function getFeedStats(bool $usesAutoTTL): array
@@ -218,20 +226,24 @@ LEFT JOIN (
 ) AS stats ON feed.id = stats.id_feed
 WHERE {$where}
 GROUP BY feed.id
-ORDER BY `avgTTL` = 0, `avgTTL` ASC
+ORDER BY COALESCE(({$lastAttempt} - MIN(stats.date)) / COUNT(1), 0) = 0, `avgTTL` ASC
 LIMIT {$this->statsCount}
 SQL;
 
         $stm = $this->pdo->query($sql);
-        $res = $stm->fetchAll(PDO::FETCH_NAMED);
+        if ($stm !== false) {
+            $list = [];
+            foreach ($stm->fetchAll(PDO::FETCH_NAMED) as $feed) {
+                $baseTTL = $this->calcAdjustedTTL((int) $feed['avgTTL']);
+                $list[] = new StatItem($feed, $baseTTL, $this->maxTTL);
+            }
 
-        $list = [];
-        foreach ($res as $feed) {
-            $baseTTL = $this->calcAdjustedTTL((int) $feed['avgTTL']);
-            $list[] = new StatItem($feed, $baseTTL, $this->maxTTL);
+            return $list;
         }
 
-        return $list;
+        Minz_Log::error('AutoTTL SQL error ' . __METHOD__ . ' ' . json_encode($this->pdo->errorInfo()));
+
+        return [];
     }
 
     public function formatLastAttempt(StatItem $feed, int $now): string

--- a/tests/AutoTTLStatsTest.php
+++ b/tests/AutoTTLStatsTest.php
@@ -138,6 +138,72 @@ final class AutoTTLStatsTest extends TestCase
         }
     }
 
+    public function test_get_feed_stats(): void
+    {
+        $defaultTTL = 3600;
+        $maxTTL = 86400;
+
+        $autoTTLFeed = null;
+        $erroredFeed = null;
+        $customTTLFeed = null;
+        try {
+            $autoTTLFeed = FreshRSS_feed_Controller::addFeed('http://wiremock:8080/three_per_day.xml');
+            $erroredFeed = FreshRSS_feed_Controller::addFeed('http://wiremock:8080/two_close.xml');
+            $customTTLFeed = FreshRSS_feed_Controller::addFeed('http://wiremock:8080/three_per_day.xml?custom_ttl');
+
+            $feedDAO = FreshRSS_Factory::createFeedDao();
+            $now = time();
+
+            // getFeedStats() reads feed.lastUpdate straight from the DB (unlike
+            // getAdjustedTTL(), which takes it as a parameter), so pin it to a
+            // known value to make the avgTTL assertion below deterministic.
+            $feedDAO->updateLastUpdate($autoTTLFeed->id(), strtotime('2000-01-01T16:00:00Z'));
+
+            // Push lastUpdate back first so the error timestamp set below is more
+            // recent than it, which is what makes calcIsErroring() consider the feed erroring.
+            $feedDAO->updateLastUpdate($erroredFeed->id(), $now - 86400);
+            $feedDAO->updateLastError($erroredFeed->id(), $now - 600);
+            $feedDAO->updateFeed($customTTLFeed->id(), ['ttl' => 1800]);
+
+            $stats = new AutoTTLStats($defaultTTL, $maxTTL, 100);
+            $stats->setTimeSource(new MockTime(strtotime('2000-01-02T00:00:00Z')));
+
+            $autoTTLStats = $stats->getFeedStats(true);
+            $autoTTLIds = array_map(fn (StatItem $item) => $item->id, $autoTTLStats);
+
+            $this->assertContains($autoTTLFeed->id(), $autoTTLIds);
+            $this->assertContains($erroredFeed->id(), $autoTTLIds);
+            $this->assertNotContains($customTTLFeed->id(), $autoTTLIds);
+
+            foreach ($autoTTLStats as $item) {
+                if ($item->id === $autoTTLFeed->id()) {
+                    $this->assertFalse($item->isErroring);
+                    // (16:00 - 00:00) / 3 = 19200 seconds
+                    $this->assertSame(19200, $item->avgTTL);
+                } elseif ($item->id === $erroredFeed->id()) {
+                    $this->assertTrue($item->isErroring);
+                }
+            }
+
+            $customTTLStats = $stats->getFeedStats(false);
+            $customTTLIds = array_map(fn (StatItem $item) => $item->id, $customTTLStats);
+
+            $this->assertContains($customTTLFeed->id(), $customTTLIds);
+            $this->assertNotContains($autoTTLFeed->id(), $customTTLIds);
+            $this->assertNotContains($erroredFeed->id(), $customTTLIds);
+        } finally {
+            if ($autoTTLFeed !== null) {
+                FreshRSS_feed_Controller::deleteFeed($autoTTLFeed->id());
+            }
+            if ($erroredFeed !== null) {
+                FreshRSS_feed_Controller::deleteFeed($erroredFeed->id());
+            }
+            if ($customTTLFeed !== null) {
+                FreshRSS_feed_Controller::deleteFeed($customTTLFeed->id());
+            }
+        }
+    }
+
     public function test_stat_item_last_attempt(): void
     {
         $baseTTL = 3600;


### PR DESCRIPTION
## Summary

Fixes #40 — after v0.6.5, opening the extension's configure page threw an uncaught fatal error on PostgreSQL-backed installs:

```
PHP Fatal error: Uncaught Error: Call to a member function fetchAll() on false in stats.php:226
```

Two changes:

- **Root cause fix**: `getFeedStats()`'s `ORDER BY` referenced the `avgTTL` output alias inside a comparison expression (`` `avgTTL` = 0 ``). PostgreSQL only resolves an alias in `ORDER BY` when it's a bare column reference — wrapped in an expression, it instead looks for a real input column named `avgTTL` and fails with `column "avgTTL" does not exist`. MySQL and SQLite are lenient about this, so it only broke on Postgres. Restored the pre-v0.6.5 pattern of repeating the full expression for that comparison term.
- **Defensive hardening**: `getAdjustedTTL()` and `getFeedStats()` now check the query result for `false` and log + fall back safely instead of crashing. FreshRSS opens PDO connections with `ERRMODE_SILENT`, so a failed query returns `false` rather than throwing, and calling `fetch()`/`fetchAll()` on that produced the uncaught error — this mirrors the pattern FreshRSS core itself uses for the same failure mode (`FeedDAO::listFeedsOrderUpdate`).

Also added `test_get_feed_stats()`, since `getFeedStats()` previously had zero test coverage despite CI already matrixing sqlite/mysql/postgres — this is what should have caught the original regression, and it's what surfaced the exact Postgres error while working on this fix.

## Test plan

- [x] `php -l` clean on changed files
- [x] `phpstan analyse` clean
- [x] `./vendor/bin/phpunit tests` passes locally against sqlite
- [x] Full `test.sh` (docker compose matrix: sqlite, mysql, postgres + wiremock) passes, including the new `test_get_feed_stats` test, confirmed by repo owner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when feed statistics queries or data fetches fail.
  * Failed statistics requests now return safe defaults instead of incomplete results.
  * Average TTL calculations now use the most recent attempt timestamp.
  * Feed error states are detected more accurately.

* **Tests**
  * Added coverage for automatic and custom TTL feeds, filtering, average TTL calculations, error detection, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->