### PR TITLE
Fix "not enough data" feeds getting defaultTTL instead of maxTTL

### DIFF
--- a/stats.php
+++ b/stats.php
@@ -163,7 +163,7 @@ class AutoTTLStats extends Minz_ModelPdo
             return $this->defaultTTL;
         }
 
-        if ($avgTTL === 0 || $avgTTL > $this->maxTTL) {
+        if ($avgTTL <= 0 || $avgTTL > $this->maxTTL) {
             return $this->maxTTL;
         } elseif ($avgTTL < $this->defaultTTL) {
             return $this->defaultTTL;
@@ -178,7 +178,7 @@ class AutoTTLStats extends Minz_ModelPdo
 SELECT
     COALESCE(({$lastUpdate} - MIN(stats.date)) / COUNT(1), 0) AS `avgTTL`
 FROM `_entry` AS stats
-WHERE id_feed = {$feedID} AND date > {$this->getStatsCutoff()}
+WHERE id_feed = {$feedID} AND date > {$this->getStatsCutoff()} AND date <= {$lastUpdate}
 SQL;
 
         $stm = $this->pdo->query($sql);
@@ -223,7 +223,7 @@ LEFT JOIN (
     SELECT id_feed, date
     FROM `_entry`
     WHERE date > {$this->getStatsCutoff()}
-) AS stats ON feed.id = stats.id_feed
+) AS stats ON feed.id = stats.id_feed AND stats.date <= {$lastAttempt}
 WHERE {$where}
 GROUP BY feed.id
 ORDER BY COALESCE(({$lastAttempt} - MIN(stats.date)) / COUNT(1), 0) = 0, `avgTTL` ASC

--- a/tests/AutoTTLStatsTest.php
+++ b/tests/AutoTTLStatsTest.php
@@ -164,7 +164,10 @@ final class AutoTTLStatsTest extends TestCase
             $stats->setTimeSource(new MockTime(strtotime("2000-01-02T00:00:00Z")));
             $adjustedTTL = $stats->getAdjustedTTL($feed->id(), strtotime("2000-01-01T16:00:00Z"));
 
-            // Entries dated in 2027/2028 are after lastAttempt, so they must be
+            // future_dated.xml's entries are dated relative to real time (wiremock's
+            // "now" templating helper, offset +2/+3 years) rather than a fixed
+            // calendar date, so this stays true regardless of when the test runs.
+            // They're after lastAttempt (fixed at year 2000 here), so they must be
             // excluded from the average instead of making it negative. avgTTL
             // resolves to 0 ("not enough data"), which must map to maxTTL, not
             // defaultTTL (regression test for linuxdaw.org/rss.xml issue).
@@ -225,10 +228,14 @@ final class AutoTTLStatsTest extends TestCase
                 } elseif ($item->id === $erroredFeed->id()) {
                     $this->assertTrue($item->isErroring);
                 } elseif ($item->id === $futureDatedFeed->id()) {
-                    // Entries dated in 2027/2028 are after lastUpdate, so they must
-                    // be excluded from the average instead of making it negative.
-                    // avgTTL resolves to 0 ("not enough data"), which must map to
-                    // maxTTL, not defaultTTL (regression test for linuxdaw.org/rss.xml issue).
+                    // future_dated.xml's entries are dated relative to real time
+                    // (wiremock's "now" templating helper, offset +2/+3 years)
+                    // rather than a fixed calendar date, so this stays true
+                    // regardless of when the test runs. They're after lastUpdate
+                    // (fixed at year 2000 here), so they must be excluded from the
+                    // average instead of making it negative. avgTTL resolves to 0
+                    // ("not enough data"), which must map to maxTTL, not defaultTTL
+                    // (regression test for linuxdaw.org/rss.xml issue).
                     $this->assertSame(0, $item->avgTTL);
                     $this->assertSame($maxTTL, $item->baseTTL);
                 }

--- a/tests/AutoTTLStatsTest.php
+++ b/tests/AutoTTLStatsTest.php
@@ -57,6 +57,19 @@ final class AutoTTLStatsTest extends TestCase
         $this->assertSame($maxTTL, $adjustedTTL);
     }
 
+    public function test_avg_ttl_negative(): void
+    {
+        $defaultTTL = 3600;
+        $maxTTL = 86400;
+
+        $stats = new AutoTTLStats($defaultTTL, $maxTTL, 100);
+        $adjustedTTL = $stats->calcAdjustedTTL(-100);
+
+        // maxTTL returned, not defaultTTL: a negative avgTTL (e.g. from a feed
+        // with future-dated entries) means "not enough data", same as zero.
+        $this->assertSame($maxTTL, $adjustedTTL);
+    }
+
     public function test_avg_ttl_gt_max_ttl(): void
     {
         $defaultTTL = 3600;
@@ -138,6 +151,31 @@ final class AutoTTLStatsTest extends TestCase
         }
     }
 
+    public function test_get_avg_ttl_future_dated_entries_ignored(): void
+    {
+        $defaultTTL = 3600;
+        $maxTTL = 86400;
+
+        $feed = null;
+        try {
+            $feed = FreshRSS_feed_Controller::addFeed('http://wiremock:8080/future_dated.xml');
+
+            $stats = new AutoTTLStats($defaultTTL, $maxTTL, 100);
+            $stats->setTimeSource(new MockTime(strtotime("2000-01-02T00:00:00Z")));
+            $adjustedTTL = $stats->getAdjustedTTL($feed->id(), strtotime("2000-01-01T16:00:00Z"));
+
+            // Entries dated in 2027/2028 are after lastAttempt, so they must be
+            // excluded from the average instead of making it negative. avgTTL
+            // resolves to 0 ("not enough data"), which must map to maxTTL, not
+            // defaultTTL (regression test for linuxdaw.org/rss.xml issue).
+            $this->assertSame($maxTTL, $adjustedTTL);
+        } finally {
+            if ($feed !== null) {
+                FreshRSS_feed_Controller::deleteFeed($feed->id());
+            }
+        }
+    }
+
     public function test_get_feed_stats(): void
     {
         $defaultTTL = 3600;
@@ -146,10 +184,12 @@ final class AutoTTLStatsTest extends TestCase
         $autoTTLFeed = null;
         $erroredFeed = null;
         $customTTLFeed = null;
+        $futureDatedFeed = null;
         try {
             $autoTTLFeed = FreshRSS_feed_Controller::addFeed('http://wiremock:8080/three_per_day.xml');
             $erroredFeed = FreshRSS_feed_Controller::addFeed('http://wiremock:8080/two_close.xml');
             $customTTLFeed = FreshRSS_feed_Controller::addFeed('http://wiremock:8080/three_per_day.xml?custom_ttl');
+            $futureDatedFeed = FreshRSS_feed_Controller::addFeed('http://wiremock:8080/future_dated.xml');
 
             $feedDAO = FreshRSS_Factory::createFeedDao();
             $now = time();
@@ -158,6 +198,7 @@ final class AutoTTLStatsTest extends TestCase
             // getAdjustedTTL(), which takes it as a parameter), so pin it to a
             // known value to make the avgTTL assertion below deterministic.
             $feedDAO->updateLastUpdate($autoTTLFeed->id(), strtotime('2000-01-01T16:00:00Z'));
+            $feedDAO->updateLastUpdate($futureDatedFeed->id(), strtotime('2000-01-01T16:00:00Z'));
 
             // Push lastUpdate back first so the error timestamp set below is more
             // recent than it, which is what makes calcIsErroring() consider the feed erroring.
@@ -173,6 +214,7 @@ final class AutoTTLStatsTest extends TestCase
 
             $this->assertContains($autoTTLFeed->id(), $autoTTLIds);
             $this->assertContains($erroredFeed->id(), $autoTTLIds);
+            $this->assertContains($futureDatedFeed->id(), $autoTTLIds);
             $this->assertNotContains($customTTLFeed->id(), $autoTTLIds);
 
             foreach ($autoTTLStats as $item) {
@@ -182,6 +224,13 @@ final class AutoTTLStatsTest extends TestCase
                     $this->assertSame(19200, $item->avgTTL);
                 } elseif ($item->id === $erroredFeed->id()) {
                     $this->assertTrue($item->isErroring);
+                } elseif ($item->id === $futureDatedFeed->id()) {
+                    // Entries dated in 2027/2028 are after lastUpdate, so they must
+                    // be excluded from the average instead of making it negative.
+                    // avgTTL resolves to 0 ("not enough data"), which must map to
+                    // maxTTL, not defaultTTL (regression test for linuxdaw.org/rss.xml issue).
+                    $this->assertSame(0, $item->avgTTL);
+                    $this->assertSame($maxTTL, $item->baseTTL);
                 }
             }
 
@@ -200,6 +249,9 @@ final class AutoTTLStatsTest extends TestCase
             }
             if ($customTTLFeed !== null) {
                 FreshRSS_feed_Controller::deleteFeed($customTTLFeed->id());
+            }
+            if ($futureDatedFeed !== null) {
+                FreshRSS_feed_Controller::deleteFeed($futureDatedFeed->id());
             }
         }
     }

--- a/wiremock/__files/future_dated.xml
+++ b/wiremock/__files/future_dated.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Example Feed</title>
+  <entry>
+    <title>One</title>
+    <updated>2027-07-29T00:00:00Z</updated>
+    <summary>Some text.</summary>
+  </entry>
+  <entry>
+    <title>Two</title>
+    <updated>2028-08-04T00:00:00Z</updated>
+    <summary>Some text.</summary>
+  </entry>
+</feed>

--- a/wiremock/__files/future_dated.xml
+++ b/wiremock/__files/future_dated.xml
@@ -3,12 +3,12 @@
   <title>Example Feed</title>
   <entry>
     <title>One</title>
-    <updated>2027-07-29T00:00:00Z</updated>
+    <updated>{{now offset='2 years' format="yyyy-MM-dd'T'HH:mm:ss'Z'"}}</updated>
     <summary>Some text.</summary>
   </entry>
   <entry>
     <title>Two</title>
-    <updated>2028-08-04T00:00:00Z</updated>
+    <updated>{{now offset='3 years' format="yyyy-MM-dd'T'HH:mm:ss'Z'"}}</updated>
     <summary>Some text.</summary>
   </entry>
 </feed>


### PR DESCRIPTION
## Summary
- Feeds whose entries are dated in the future (e.g. `linuxdaw.org/rss.xml`, which serves `pubDate`s years ahead) produced a **negative** `avgTTL`, because the SQL had no upper bound excluding entries dated after the feed's last fetch attempt.
- `calcAdjustedTTL()` then treated that negative value as "updates too frequently" and returned `defaultTTL`, instead of the `maxTTL` fallback intended for "not enough data" feeds — even though the stats table correctly showed "not enough data" for that row.
- Fixed by bounding both `avgTTL` queries (`getAdjustedTTL()` and `getFeedStats()`) to entries dated on or before the feed's last attempt, and by treating any non-positive `avgTTL` (not just exactly `0`) as "not enough data" in `calcAdjustedTTL()` as defense in depth.

## Test plan
- [x] Added `wiremock/__files/future_dated.xml` fixture with entries dated in 2027/2028
- [x] Added `test_avg_ttl_negative` unit test asserting `calcAdjustedTTL(-100)` returns `maxTTL`
- [x] Added `test_get_avg_ttl_future_dated_entries_ignored` regression test via `getAdjustedTTL()`
- [x] Extended `test_get_feed_stats` to cover the future-dated feed via `getFeedStats()`, asserting `avgTTL === 0` and `baseTTL === maxTTL`
- [x] Verified against a mock SQLite DB that the old query produced a large negative `avgTTL` for future-dated entries, and the fixed query correctly produces `0`
- [x] Run `./test.sh` (sqlite/mysql/postgres) — could not run in this sandbox (no Docker daemon access), needs CI/maintainer verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)